### PR TITLE
Reducing rate-limiting and hyperparameter tuning bug fix

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -67,7 +67,7 @@ Next, initialize :py:class:`nbaspa.data.factory.NBADataFactory` and download the
 .. important::
 
     We use `ratelimit <https://github.com/tomasbasham/ratelimit>`_ to prevent overloading the
-    NBA API. The ratelimiting is **very** conservative and limits to 5 calls every 10 minutes.
+    NBA API. The ratelimiting is **very** conservative and limits to 5 calls every 5 minutes.
 
 ~~~~~~~~~~~~~~~~~~~~~~
 Command-line interface

--- a/nbaspa/data/endpoints/parameters.py
+++ b/nbaspa/data/endpoints/parameters.py
@@ -18,6 +18,10 @@ else:
     CURRENT_SEASON_YEAR = str(TODAY.year - 1)
 
 SEASONS: Dict = {
+    "2016-17": {
+        "START": datetime.datetime.strptime("2016-10-25", "%Y-%m-%d"),
+        "END": datetime.datetime.strptime("2017-04-12", "%Y-%m-%d")
+    },
     "2017-18": {
         "START": datetime.datetime.strptime("2017-10-17", "%Y-%m-%d"),
         "END": datetime.datetime.strptime("2018-04-11", "%Y-%m-%d"),

--- a/nbaspa/data/factory.py
+++ b/nbaspa/data/factory.py
@@ -15,7 +15,7 @@ from .endpoints.base import BaseRequest
 
 LOG = logging.getLogger(__name__)
 
-TEN_MINUTES = 600
+FIVE_MINUTES = 300
 
 
 class NBADataFactory:
@@ -121,7 +121,7 @@ class NBADataFactory:
         return pd.concat(df_list).reset_index(drop=True)
 
     @sleep_and_retry
-    @limits(calls=5, period=TEN_MINUTES)
+    @limits(calls=5, period=FIVE_MINUTES)
     def _get(self, callobj: BaseRequest):
         """Run the ``get()`` method to retrieve data.
 

--- a/nbaspa/model/tasks/tuning.py
+++ b/nbaspa/model/tasks/tuning.py
@@ -67,7 +67,12 @@ class LifelinesTuning(Task):
         def func(params):
             model = CoxTimeVaryingFitter(**params, **kwargs)
             model.fit(
-                train_data,
+                train_data[
+                    [META["id"], META["event"]]
+                    + ["start", "stop"]
+                    + META["static"]
+                    + META["dynamic"]
+                ],
                 id_col=META["id"],
                 event_col=META["event"],
                 start_col="start",


### PR DESCRIPTION
In this PR I have

* Reduced the rate-limiting (5 calls per 5 minutes instead of 5 per 10 minutes),
* Ensured the variable set is consistent in the lifelines training,
* Added 2016-17 season bounds to the parameter values