### PR TITLE
Adding season summary and player time series information

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -436,6 +436,9 @@ and to restrict to a game, supply ``GameID``
 
     You can find the play-by-play impact data at ``<output_dir>/<Season>/pbp-impact/data_<GameID>.csv``.
     The aggregated game-level data can be found at ``<output_dir>/<Season>/game-impact/data_<GameID>/csv``.
+    This call will also save a season summary CSV with total and average impact for each player to
+    ``<output_dir>/<Season>/impact-summary.csv``, as well as player timeseries data to
+    ``<output_dir>/<Season>/impact-timeseries/data_<PlayerID>.csv``.
 
 ~~~~~~~~~~~~~~~~~~~~~~
 Command-line interface

--- a/nbaspa/player_rating/pipeline.py
+++ b/nbaspa/player_rating/pipeline.py
@@ -18,7 +18,7 @@ from .tasks import (
     SimplePlayerImpact,
     SaveImpactData,
     SavePlayerTimeSeries,
-    SaveTopPlayers
+    SaveTopPlayers,
 )
 
 
@@ -119,7 +119,7 @@ def run_pipeline(
     """
     output = flow.run(
         parameters={"data_dir": data_dir, "output_dir": output_dir, **kwargs},
-        executor=LocalDaskExecutor(scheduler="processes")
+        executor=LocalDaskExecutor(scheduler="processes"),
     )
 
     return output

--- a/nbaspa/player_rating/tasks/__init__.py
+++ b/nbaspa/player_rating/tasks/__init__.py
@@ -11,7 +11,7 @@ from .io import (
     LoadSurvivalPredictions,
     SaveImpactData,
     SavePlayerTimeSeries,
-    SaveTopPlayers
+    SaveTopPlayers,
 )
 from .join import AddSurvivalProbability
 

--- a/nbaspa/player_rating/tasks/__init__.py
+++ b/nbaspa/player_rating/tasks/__init__.py
@@ -9,6 +9,7 @@ from .io import (
     BoxScoreLoader,
     LoadSurvivalPredictions,
     SaveImpactData,
+    SaveTopPlayers
 )
 from .join import AddSurvivalProbability
 
@@ -22,4 +23,5 @@ __all__: List[str] = [
     "LoadSurvivalPredictions",
     "AddSurvivalProbability",
     "SaveImpactData",
+    "SaveTopPlayers",
 ]

--- a/nbaspa/player_rating/tasks/__init__.py
+++ b/nbaspa/player_rating/tasks/__init__.py
@@ -6,9 +6,11 @@ from .impact import AggregateImpact, CompoundPlayerImpact, SimplePlayerImpact
 from .io import (
     GetGamesList,
     LoadRatingData,
+    ScoreboardLoader,
     BoxScoreLoader,
     LoadSurvivalPredictions,
     SaveImpactData,
+    SavePlayerTimeSeries,
     SaveTopPlayers
 )
 from .join import AddSurvivalProbability
@@ -19,9 +21,11 @@ __all__: List[str] = [
     "SimplePlayerImpact",
     "GetGamesList",
     "LoadRatingData",
+    "ScoreboardLoader",
     "BoxScoreLoader",
     "LoadSurvivalPredictions",
     "AddSurvivalProbability",
     "SaveImpactData",
+    "SavePlayerTimeSeries",
     "SaveTopPlayers",
 ]


### PR DESCRIPTION
In this PR, I have added the following functionality to the player rating CLI call:

* Saving a "season summary" with the total and average impact for each player, and
* Saving "player timeseries" data for each season.